### PR TITLE
Add some base godot ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+.import/
+export.cfg
+export_presets.cfg
+.DS_Store


### PR DESCRIPTION
Just some additions to the gitignore that are helpful for godot development. Import prevents the pain suffering and agony of having to rebuild the import files on everyone's devices, exports have the same issues, and .DS_Store is an OSX-exclusive folder info file that is unneeded.